### PR TITLE
Co-smooth mode in Masker

### DIFF
--- a/src/configs/ndt1.yaml
+++ b/src/configs/ndt1.yaml
@@ -12,9 +12,10 @@ encoder:
     ratio: 0.1          # ratio of data to predict
     zero_ratio: 1.0     # of the data to predict, ratio of zeroed out
     random_ratio: 1.0   # of the not zeroed, ratio of randomly replaced
-    expand_prob: 0.0    # probability of expanding the mask in temporal mode
+    expand_prob: 0.0    # probability of expanding the mask in ``temporal`` mode
     max_timespan: 1     # max span of mask if expanded
-    regions: null       # brain regions to mask in region mode
+    regions: null       # brain regions to mask in ``region`` mode
+    channels: null       # neurons to mask in ``co-smooth`` mode
 
   # Context available for each timestep
   context:


### PR DESCRIPTION
Add a co-smooth mode in the Masker where a fixed set of channels are always masked